### PR TITLE
Update Autonomous driving application - Car detection - v1.ipynb

### DIFF
--- a/Convolutional Neural Networks/Week3/Car detection for Autonomous Driving/Autonomous driving application - Car detection - v1.ipynb
+++ b/Convolutional Neural Networks/Week3/Car detection for Autonomous Driving/Autonomous driving application - Car detection - v1.ipynb
@@ -400,7 +400,7 @@
     "    yi1 = max(box1[1], box2[1])\n",
     "    xi2 = min(box1[2], box2[2])\n",
     "    yi2 = min(box1[3], box2[3])\n",
-    "    inter_area = (xi2 - xi1)*(yi2 - yi1)\n",
+    "    inter_area = max((xi2 - xi1), 0)*max((yi2 - yi1), 0)\n",
     "    ### END CODE HERE ###    \n",
     "\n",
     "    # Calculate the Union area by using Formula: Union(A,B) = A + B - Inter(A,B)\n",


### PR DESCRIPTION
In order to compute the intersection area, you need to make sure the height and width of the intersection are positive, otherwise the intersection area should be zero.